### PR TITLE
Remove experimental file permissions

### DIFF
--- a/gradle/build-logic/src/main/kotlin/publish.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/publish.gradle.kts
@@ -48,10 +48,4 @@ tasks.withType<AbstractPublishToMaven>().configureEach {
 tasks.withType<AbstractArchiveTask>().configureEach {
     isPreserveFileTimestamps = false
     isReproducibleFileOrder = true
-    filePermissions {
-        unix(644)
-    }
-    dirPermissions {
-        unix(755)
-    }
 }


### PR DESCRIPTION
No idea, but https://github.com/hfhbd/actions/pull/12 fails with `package.json (Permission denied)`, part of the published js artifact.