### PR TITLE
Fix file permissions

### DIFF
--- a/gradle/build-logic/src/main/kotlin/publish.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/publish.gradle.kts
@@ -49,9 +49,9 @@ tasks.withType<AbstractArchiveTask>().configureEach {
     isPreserveFileTimestamps = false
     isReproducibleFileOrder = true
     filePermissions {
-        unix(644)
+        unix("644")
     }
     dirPermissions {
-        unix(755)
+        unix("755")
     }
 }


### PR DESCRIPTION
See https://github.com/gradle/gradle/issues/10900
The `unix` function does not support a non octal integer. Either convert it to base 10 (420/493) or use a String.