### PR TITLE
Remove develocity in integration-test

### DIFF
--- a/integration-test/settings.gradle.kts
+++ b/integration-test/settings.gradle.kts
@@ -10,19 +10,6 @@ pluginManagement {
 plugins {
     id("myRepos")
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
-    id("com.gradle.develocity") version "3.17.5"
-}
-
-develocity {
-    buildScan {
-        termsOfUseUrl.set("https://gradle.com/terms-of-service")
-        termsOfUseAgree.set("yes")
-        val isCI = providers.environmentVariable("CI").isPresent
-        publishing {
-            onlyIf { isCI }
-        }
-        tag("CI")
-    }
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
To prevent CCE with the same type but loaded with different class loaders.